### PR TITLE
Email validator add custom options support

### DIFF
--- a/lib/emailable/email_validator.rb
+++ b/lib/emailable/email_validator.rb
@@ -51,7 +51,11 @@ class EmailValidator < ActiveModel::EachValidator
     error ||= :disposable if ev.disposable? && !disposable
     error ||= :accept_all if ev.accept_all? && !accept_all
 
-    record.errors.add(attribute, error) if error
+    if error
+      error_options = options.except(:smtp, :states, :free, :role,
+                                     :disposable, :accept_all, :timeout)
+      record.errors.add(attribute, error, **error_options)
+    end
   rescue Emailable::Error
     # silence errors
   end

--- a/lib/emailable/email_validator.rb
+++ b/lib/emailable/email_validator.rb
@@ -52,8 +52,9 @@ class EmailValidator < ActiveModel::EachValidator
     error ||= :accept_all if ev.accept_all? && !accept_all
 
     if error
-      error_options = options.except(:smtp, :states, :free, :role,
-                                     :disposable, :accept_all, :timeout)
+      error_options = options.except(
+        :smtp, :states, :free, :role, :disposable, :accept_all, :timeout
+      )
       record.errors.add(attribute, error, **error_options)
     end
   rescue Emailable::Error

--- a/test/email_validator_test.rb
+++ b/test/email_validator_test.rb
@@ -85,13 +85,14 @@ class EmailValidatorTest < Minitest::Test
 
   def test_custom_option
     message = 'invalid message'
-    valid_user = user_class(message: message, reportable: true)
-                   .new(email: 'undeliverable@example.com')
+    invalid_user = user_class(message: message, reportable: true).new(
+      email: 'undeliverable@example.com'
+    )
 
-    assert !valid_user.valid?
-    assert valid_user.errors[:email].present?
-    assert valid_user.errors[:email].first == message
-    assert valid_user.errors.where(:email, reportable: true).present?
+    refute invalid_user.valid?
+    assert invalid_user.errors[:email].present?
+    assert_equal message, invalid_user.errors[:email].first
+    assert invalid_user.errors.where(:email, reportable: true).present?
   end
 
 end

--- a/test/email_validator_test.rb
+++ b/test/email_validator_test.rb
@@ -5,7 +5,7 @@ class EmailValidatorTest < Minitest::Test
 
   def user_class(
     smtp: true, states: %i[deliverable risky unknown], free: true, role: true,
-    accept_all: true, disposable: true, timeout: 3
+    accept_all: true, disposable: true, timeout: 3, **options
   )
     Class.new do
       include ActiveModel::Model
@@ -15,7 +15,7 @@ class EmailValidatorTest < Minitest::Test
         smtp: smtp, states: states,
         free: free, role: role, disposable: disposable, accept_all: accept_all,
         timeout: timeout
-      }
+      }.merge(options)
 
       def self.name
         'TestClass'
@@ -81,6 +81,17 @@ class EmailValidatorTest < Minitest::Test
     assert !valid_user.valid?
     assert_raises(ArgumentError) { invalid_user1.valid? }
     assert_raises(ArgumentError) { invalid_user2.valid? }
+  end
+
+  def test_custom_option
+    message = 'invalid message'
+    valid_user = user_class(message: message, reportable: true)
+                   .new(email: 'undeliverable@example.com')
+
+    assert !valid_user.valid?
+    assert valid_user.errors[:email].present?
+    assert valid_user.errors[:email].first == message
+    assert valid_user.errors.where(:email, reportable: true).present?
   end
 
 end


### PR DESCRIPTION
#11 
Allows users to pass in custom options when using the email validator