### PR TITLE
Change authentication priority

### DIFF
--- a/lib/emailable/client.rb
+++ b/lib/emailable/client.rb
@@ -22,7 +22,7 @@ module Emailable
 
       uri = URI("#{@base_url}/#{endpoint}")
       headers = {
-        'Authorization': "Bearer #{Emailable.api_key || api_key || access_token}",
+        'Authorization': "Bearer #{api_key || access_token || Emailable.api_key}",
         'Content-Type': 'application/json'
       }
 

--- a/test/authentication_test.rb
+++ b/test/authentication_test.rb
@@ -24,4 +24,10 @@ class AuthenticationTest < Minitest::Test
     refute_nil Emailable::Batch.new(bid).status(api_key: @api_key).id
   end
 
+  def test_request_time_authentication_takes_priority_over_global
+    Emailable.api_key = 'invalid_api_key'
+
+    refute_nil Emailable.verify(@email, api_key: @api_key).domain
+  end
+
 end


### PR DESCRIPTION
The `api_key` or `access_token` passed into a request will take priority over the globally configured API key.